### PR TITLE
Add dictionary compression support

### DIFF
--- a/blockFetcher/BlockDB.ts
+++ b/blockFetcher/BlockDB.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { RpcBlock, RpcBlockTransaction, RpcTxReceipt, RpcTraceResult, StoredTx } from './evmTypes';
-import { compress as zstdCompress, decompress as zstdDecompress } from 'zstd-napi';
+import { compress as zstdCompress, decompress as zstdDecompress, Compressor as ZstdCompressor, Decompressor as ZstdDecompressor } from 'zstd-napi';
 import { StoredBlock } from './BatchRpc';
 
 export class BlockDB {
@@ -8,6 +8,15 @@ export class BlockDB {
     private prepped: Map<string, any>;
     private isReadonly: boolean;
     private hasDebug: boolean;
+    private blockDict: Buffer | null = null;
+    private txDict: Buffer | null = null;
+    private traceDict: Buffer | null = null;
+    private blockCompressor: ZstdCompressor;
+    private blockDecompressor: ZstdDecompressor;
+    private txCompressor: ZstdCompressor;
+    private txDecompressor: ZstdDecompressor;
+    private traceCompressor: ZstdCompressor;
+    private traceDecompressor: ZstdDecompressor;
 
     constructor({ path, isReadonly, hasDebug }: { path: string, isReadonly: boolean, hasDebug: boolean }) {
         this.db = new Database(path, {
@@ -19,6 +28,38 @@ export class BlockDB {
             this.initSchema();
         }
         this.prepped = new Map();
+
+        this.blockCompressor = new ZstdCompressor();
+        this.blockDecompressor = new ZstdDecompressor();
+        this.txCompressor = new ZstdCompressor();
+        this.txDecompressor = new ZstdDecompressor();
+        this.traceCompressor = new ZstdCompressor();
+        this.traceDecompressor = new ZstdDecompressor();
+
+        // Load any stored dictionaries
+        try {
+            const selectDicts = this.db.prepare('SELECT name, dict FROM dictionaries');
+            const rows = selectDicts.all() as Array<{ name: string; dict: Buffer }>;
+            for (const row of rows) {
+                if (row.name === 'blocks') this.blockDict = row.dict;
+                else if (row.name === 'txs') this.txDict = row.dict;
+                else if (row.name === 'traces') this.traceDict = row.dict;
+            }
+        } catch {
+            // Table may not exist on older databases
+        }
+        if (this.blockDict) {
+            this.blockCompressor.loadDictionary(this.blockDict);
+            this.blockDecompressor.loadDictionary(this.blockDict);
+        }
+        if (this.txDict) {
+            this.txCompressor.loadDictionary(this.txDict);
+            this.txDecompressor.loadDictionary(this.txDict);
+        }
+        if (this.traceDict) {
+            this.traceCompressor.loadDictionary(this.traceDict);
+            this.traceDecompressor.loadDictionary(this.traceDict);
+        }
 
         // Check and validate hasDebug setting
         const storedHasDebug = this.getHasDebug();
@@ -121,12 +162,15 @@ export class BlockDB {
 
         // Compress block data before storing
         const blockJsonStr = JSON.stringify(blockWithoutTxs);
-        const compressedBlockData = zstdCompress(Buffer.from(blockJsonStr));
+        const compressedBlockData = this.blockDict
+            ? this.blockCompressor.compress(Buffer.from(blockJsonStr))
+            : zstdCompress(Buffer.from(blockJsonStr));
+        const blockCodec = this.blockDict ? 1 : 0;
 
         // Extract block hash (remove '0x' prefix and convert to Buffer)
         const blockHash = Buffer.from(storedBlock.block.hash.slice(2), 'hex');
 
-        insertBlock.run(blockNumber, blockHash, compressedBlockData, 0);
+        insertBlock.run(blockNumber, blockHash, compressedBlockData, blockCodec);
 
         // Store transactions with their receipts and traces
         for (let i = 0; i < storedBlock.block.transactions.length; ++i) {
@@ -148,7 +192,10 @@ export class BlockDB {
 
             // Compress transaction data
             const txJsonStr = JSON.stringify(txData);
-            const compressedTxData = zstdCompress(Buffer.from(txJsonStr));
+            const compressedTxData = this.txDict
+                ? this.txCompressor.compress(Buffer.from(txJsonStr))
+                : zstdCompress(Buffer.from(txJsonStr));
+            const txCodec = this.txDict ? 1 : 0;
 
             // Extract transaction hash (remove '0x' prefix and convert to Buffer)
             const txHash = Buffer.from(tx.hash.slice(2), 'hex');
@@ -166,10 +213,12 @@ export class BlockDB {
                 }
                 const trace = traces[0]!;
                 const traceJsonStr = JSON.stringify(trace);
-                compressedTraceData = zstdCompress(Buffer.from(traceJsonStr));
+                compressedTraceData = this.traceDict
+                    ? this.traceCompressor.compress(Buffer.from(traceJsonStr))
+                    : zstdCompress(Buffer.from(traceJsonStr));
             }
 
-            insertTx.run(tx_num, txHash, compressedTxData, compressedTraceData, 0);
+            insertTx.run(tx_num, txHash, compressedTxData, compressedTraceData, txCodec);
         }
     }
 
@@ -199,6 +248,11 @@ export class BlockDB {
             key   TEXT PRIMARY KEY,
             value INTEGER NOT NULL,
             codec INTEGER NOT NULL DEFAULT 0
+          ) WITHOUT ROWID;
+
+          CREATE TABLE IF NOT EXISTS dictionaries (
+            name TEXT PRIMARY KEY,
+            dict BLOB NOT NULL
           ) WITHOUT ROWID;
         `);
     }
@@ -237,6 +291,32 @@ export class BlockDB {
         upsert.run('hasDebug', hasDebug ? 1 : 0, 0);
     }
 
+    getDictionary(name: string): Buffer | undefined {
+        const select = this.prepQuery('SELECT dict FROM dictionaries WHERE name = ?');
+        const row = select.get(name) as { dict: Buffer } | undefined;
+        return row?.dict;
+    }
+
+    setDictionary(name: string, data: Buffer) {
+        if (this.isReadonly) throw new Error('BlockDB is readonly');
+        const upsert = this.prepQuery('INSERT OR REPLACE INTO dictionaries(name, dict) VALUES (?, ?)');
+        upsert.run(name, data);
+
+        if (name === 'blocks') {
+            this.blockDict = data;
+            this.blockCompressor.loadDictionary(data);
+            this.blockDecompressor.loadDictionary(data);
+        } else if (name === 'txs') {
+            this.txDict = data;
+            this.txCompressor.loadDictionary(data);
+            this.txDecompressor.loadDictionary(data);
+        } else if (name === 'traces') {
+            this.traceDict = data;
+            this.traceCompressor.loadDictionary(data);
+            this.traceDecompressor.loadDictionary(data);
+        }
+    }
+
     getTxBatch(greaterThanTxNum: number, limit: number, includeTraces: boolean): { txs: StoredTx[], traces: RpcTraceResult[] | undefined } {
         const selectTxs = this.prepQuery(`
             SELECT tx_num, data, traces, codec 
@@ -257,12 +337,16 @@ export class BlockDB {
         const traces: RpcTraceResult[] = [];
 
         for (const row of rows) {
-            if (row.codec !== 0) {
+            let decompressedTxData: Buffer;
+            if (row.codec === 0) {
+                decompressedTxData = zstdDecompress(row.data);
+            } else if (row.codec === 1 && this.txDict) {
+                decompressedTxData = this.txDecompressor.decompress(row.data);
+            } else {
                 throw new Error(`Unsupported codec ${row.codec} for tx_num ${row.tx_num}`);
             }
 
             // Decompress and parse transaction data
-            const decompressedTxData = zstdDecompress(row.data);
             const storedTx = JSON.parse(decompressedTxData.toString()) as StoredTx;
             txs.push(storedTx);
 
@@ -271,7 +355,14 @@ export class BlockDB {
                 if (!row.traces) {
                     throw new Error(`hasDebug is true but no trace found for tx_num ${row.tx_num}`);
                 }
-                const decompressedTraceData = zstdDecompress(row.traces);
+                let decompressedTraceData: Buffer;
+                if (row.codec === 0) {
+                    decompressedTraceData = zstdDecompress(row.traces);
+                } else if (row.codec === 1 && this.traceDict) {
+                    decompressedTraceData = this.traceDecompressor.decompress(row.traces);
+                } else {
+                    throw new Error(`Unsupported codec ${row.codec} for tx_num ${row.tx_num}`);
+                }
                 const trace = JSON.parse(decompressedTraceData.toString()) as RpcTraceResult;
                 traces.push(trace);
             }
@@ -324,12 +415,16 @@ export class BlockDB {
             return null;
         }
 
-        if (blockRow.codec !== 0) {
+        let decompressedBlockData: Buffer;
+        if (blockRow.codec === 0) {
+            decompressedBlockData = zstdDecompress(blockRow.data);
+        } else if (blockRow.codec === 1 && this.blockDict) {
+            decompressedBlockData = this.blockDecompressor.decompress(blockRow.data);
+        } else {
             throw new Error(`Unsupported codec ${blockRow.codec} for block ${blockNumber}`);
         }
 
         // Decompress and parse the block data (without transactions)
-        const decompressedBlockData = zstdDecompress(blockRow.data);
         const storedBlock = JSON.parse(decompressedBlockData.toString()) as Omit<RpcBlock, 'transactions'>;
 
         // Now fetch all transactions for this block
@@ -357,12 +452,16 @@ export class BlockDB {
         const transactions: RpcBlockTransaction[] = [];
 
         for (const txRow of txRows) {
-            if (txRow.codec !== 0) {
+            let decompressedTxData: Buffer;
+            if (txRow.codec === 0) {
+                decompressedTxData = zstdDecompress(txRow.data);
+            } else if (txRow.codec === 1 && this.txDict) {
+                decompressedTxData = this.txDecompressor.decompress(txRow.data);
+            } else {
                 throw new Error(`Unsupported codec ${txRow.codec} for tx_num ${txRow.tx_num}`);
             }
 
             // Decompress and parse transaction data
-            const decompressedTxData = zstdDecompress(txRow.data);
             const storedTx = JSON.parse(decompressedTxData.toString()) as StoredTx;
 
             // Extract the RpcBlockTransaction from StoredTx


### PR DESCRIPTION
## Summary
- extend `BlockDB` to support Zstd dictionaries
- store dictionaries in new `dictionaries` table
- compress/decompress using dictionary when available

## Testing
- `npm run test:specs`


------
https://chatgpt.com/codex/tasks/task_e_6867eb5c496083319e724bceb9148a31