### PR TITLE
Improve fetcher error logging

### DIFF
--- a/blockFetcher/BatchRpc.ts
+++ b/blockFetcher/BatchRpc.ts
@@ -55,6 +55,10 @@ export class BatchRpc {
             interval: 1000, // 1 second
             intervalCap: rps
         });
+        // Prevent unhandled 'error' events from crashing the process
+        this.queue.on('error', error => {
+            console.error('BatchRpc queue error:', error);
+        });
         this.requestBatchSize = requestBatchSize;
         this.enableBatchSizeGrowth = enableBatchSizeGrowth;
         this.rpcSupportsDebug = rpcSupportsDebug;

--- a/blockFetcher/startFetchingLoop.ts
+++ b/blockFetcher/startFetchingLoop.ts
@@ -81,7 +81,7 @@ export async function startFetchingLoop(blockDB: BlockDB, batchRpc: BatchRpc, bl
             const secondsLeft = blocksLeft / blocksPerSecond;
             console.log(`[${chainName}] Fetched ${blocks.length} blocks in ${Math.round(end - start)}ms, that's ~${Math.round(blocksPerSecond)} blocks/s, ${blocksLeft.toLocaleString()} blocks left, ~${formatSeconds(secondsLeft)} left`);
         } catch (error) {
-            console.error(error);
+            console.error(`[${chainName}] Error fetching/storing blocks ${startBlock}-${endBlock}:`, error);
             await new Promise(resolve => setTimeout(resolve, ERROR_PAUSE_TIME));
         }
     }

--- a/start.ts
+++ b/start.ts
@@ -9,6 +9,14 @@ import { createApiServer } from './server.js';
 import { startSingleIndexer, getAvailableIndexers } from './indexer.js';
 import { awaitIndexerDatabases, getBlocksDbPath } from './lib/dbPaths.js';
 
+// Log any uncaught exceptions or promise rejections to aid debugging of worker crashes
+process.on('unhandledRejection', reason => {
+    console.error('Unhandled promise rejection:', reason);
+});
+process.on('uncaughtException', error => {
+    console.error('Uncaught exception:', error);
+});
+
 if (cluster.isPrimary) {
     const roles = process.env['ROLES']?.split(',') || ['fetcher', 'api', 'indexer'];
     let apiStarted = false;


### PR DESCRIPTION
## Summary
- prevent unhandled PQueue errors from crashing workers
- log range of failed blocks in the fetcher loop
- add global handlers for uncaught exceptions and unhandled rejections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875cc1c2df48331959e8b2db6d5897b