### PR TITLE
Add maxTxNum hint for filtered indexing

### DIFF
--- a/blockFetcher/BlocksDBHelper.ts
+++ b/blockFetcher/BlocksDBHelper.ts
@@ -331,12 +331,19 @@ export class BlocksDBHelper {
         );
     }
 
-    async getTxBatch(greaterThanTxNum: number, limit: number, includeTraces: boolean, filterEvents: string[] | undefined): Promise<{ txs: StoredTx[], traces: RpcTraceResult[] | undefined }> {
+    async getTxBatch(greaterThanTxNum: number, limit: number, includeTraces: boolean, filterEvents: string[] | undefined): Promise<{ txs: StoredTx[], traces: RpcTraceResult[] | undefined, maxTxNum: number }> {
         // Ensure safe values to prevent SQL injection
         const txNumParam = Math.max(0, greaterThanTxNum);
         const limitParam = Math.min(Math.max(1, limit), 100000);
 
         let query: string;
+
+        // Get the current maximum tx number to help callers skip expensive
+        // queries when no more results are available
+        const [maxRows] = await this.pool.query<mysql.RowDataPacket[]>(
+            'SELECT MAX(tx_num) AS max_tx_num FROM txs'
+        );
+        const maxTxNum = maxRows[0]?.['max_tx_num'] ?? -1;
 
         if (filterEvents && filterEvents.length > 0) {
             // Use the index for efficient filtering
@@ -383,7 +390,8 @@ export class BlocksDBHelper {
 
             return {
                 txs,
-                traces: this.hasDebug && includeTraces ? traces : undefined
+                traces: this.hasDebug && includeTraces ? traces : undefined,
+                maxTxNum
             };
         } else {
             // No filtering, use original query
@@ -413,7 +421,8 @@ export class BlocksDBHelper {
 
             return {
                 txs,
-                traces: this.hasDebug && includeTraces ? traces : undefined
+                traces: this.hasDebug && includeTraces ? traces : undefined,
+                maxTxNum
             };
         }
     }

--- a/indexer.ts
+++ b/indexer.ts
@@ -81,6 +81,10 @@ async function startIndexer(
         if (!hadSomethingToIndex) {
             consecutiveEmptyBatches++;
 
+            if (transactions.maxTxNum > lastIndexedTx) {
+                await setIntValue(pool, `lastIndexedTx_${name}`, transactions.maxTxNum);
+            }
+
             // Check if we should exit
             if (exitWhenDone && consecutiveEmptyBatches >= requiredEmptyBatches) {
                 console.log(`[${name} - ${chainConfig.chainName}] No more transactions to index after ${requiredEmptyBatches} consecutive empty batches, exiting...`);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,7 @@ export interface RegisterRoutesContext {
 export type TxBatch = {
     txs: StoredTx[];
     traces: RpcTraceResult[] | undefined;
+    maxTxNum: number;
 }
 
 /** Indexing plugin - processes blockchain data and stores in its own database */


### PR DESCRIPTION
## Summary
- include `maxTxNum` in `TxBatch`
- return maximum known tx id from `getTxBatch`
- update indexer logic to skip redundant filtered queries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a0ce26f48331ade0012f5bc07df3